### PR TITLE
fix(deps): unpin ratatui version to avoid conflicts with tui-textarea

### DIFF
--- a/tui/Cargo.toml
+++ b/tui/Cargo.toml
@@ -25,7 +25,7 @@ lazy_static = "1.4.0"
 libc = "0.2.148"
 log = "0.4.20"
 pretty_assertions = "1.4.0"
-ratatui = { version = "0.25.0", features = ["serde", "macros"] }
+ratatui = { version = ">=0.26.1, <1", features = ["serde", "macros"] }
 reqwest = {version = "0.11.23", features = ["json"]}
 serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"


### PR DESCRIPTION
Pinning the ratatui version was causing compile errors in some cases, since `tui-textarea` would pull in a different version of ratatui than what this project had pinned